### PR TITLE
fetchcrl::install: allow to disable CA repo management.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,6 +6,7 @@
 class fetchcrl (
   $capkgs = $fetchcrl::params::capkgs,
   $carepo = $fetchcrl::params::carepo,
+  $manage_carepo = $fetchcrl::params::manage_carepo,
   $capkgs_version = $fetchcrl::params::capkgs_version,
   $pkg_version = $fetchcrl::params::pkg_version,
   $agingtolerance = $fetchcrl::params::agingtolerance,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -3,6 +3,7 @@ class fetchcrl::install (
   $pkgname   = $fetchcrl::pkgname,
   $capkgs    = $fetchcrl::capkgs,
   $carepo    = $fetchcrl::carepo,
+  $manage_carepo = $fetchcrl::manage_carepo,
   $capkgs_version = $fetchcrl::capkgs_version,
   $pkg_version = $fetchcrl::pkg_version
 ) inherits fetchcrl {
@@ -12,26 +13,32 @@ class fetchcrl::install (
     ensure => $pkg_version,
   }
 
+  if $manage_carepo {
+    file{'/etc/pki/rpm-gpg/GPG-KEY-EUGridPMA-RPM-3':
+      ensure  => file,
+      source  => 'puppet:///modules/fetchcrl/GPG-KEY-EUGridPMA-RPM-3',
+      replace => false,
+      owner   => root,
+      group   => root,
+      mode    => '0644',
+    }
+
+    yumrepo{'carepo':
+      descr    => 'IGTF CA Repository',
+      enabled  => 1,
+      baseurl  => $carepo,
+      gpgcheck => 1,
+      gpgkey   => 'file:///etc/pki/rpm-gpg/GPG-KEY-EUGridPMA-RPM-3',
+      require  => File['/etc/pki/rpm-gpg/GPG-KEY-EUGridPMA-RPM-3'],
+    }
+
+    $capkgs_require = Yumrepo['carepo']
+  } else {
+    $capkgs_require = undef
+  }
   # The CA meta package.
   package{$capkgs:
     ensure  => $capkgs_version,
-    require => Yumrepo['carepo'],
-  }
-  yumrepo{'carepo':
-    descr    => 'IGTF CA Repository',
-    enabled  => 1,
-    baseurl  => $carepo,
-    gpgcheck => 1,
-    gpgkey   => 'file:///etc/pki/rpm-gpg/GPG-KEY-EUGridPMA-RPM-3',
-    require  => File['/etc/pki/rpm-gpg/GPG-KEY-EUGridPMA-RPM-3'],
-  }
-
-  file{'/etc/pki/rpm-gpg/GPG-KEY-EUGridPMA-RPM-3':
-    ensure  => file,
-    source  => 'puppet:///modules/fetchcrl/GPG-KEY-EUGridPMA-RPM-3',
-    replace => false,
-    owner   => root,
-    group   => root,
-    mode    => '0644',
+    require => $capkgs_require,
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -46,6 +46,7 @@ class fetchcrl::params {
   } else {
     $carepo         = 'http://repository.egi.eu/sw/production/cas/1/current/'
   }
+  $manage_carepo = true
   $_capkgs_version  =hiera('fetchcrl_capkgs_version',false)
   if $_capkgs_version {
     warning('fetchcrl - fetchcrl_capkgs_version is deprecated, use fetchcrl::capkgs_version instead')


### PR DESCRIPTION
PR allowing to disable yum repository managememt using the boolean fetchcrl::manage_carepo class attribute.
Users might want to manage yum repositories using some special modules (like example42/yum) and in order to do this the yumrepo/gpg keys calls should be optional.
This PR is reverse compatible as repo management is enabled by default.